### PR TITLE
fix: Remove existing Node.js `package*.json` files in Git Commit Linter

### DIFF
--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Install Dependencies
         run: |
+          rm -f package.json package-lock.json
+
           npm install @commitlint/cli@"${COMMITLINT_CLI_VERSION}"
           npm install @commitlint/config-conventional@"${COMMITLINT_CONFIG_CONVENTIONAL_VERSION}"
         env:


### PR DESCRIPTION
If a `package.json` file exists, NPM will always install every dependency specified in it, even if using `npm install` to install only a single specific package.

Related GitHub issue: https://github.com/npm/cli/issues/3023