### PR TITLE
Remove GitHub Dependency Review configuration for FOSS

### DIFF
--- a/.github/dependency-review-config-foss.yaml
+++ b/.github/dependency-review-config-foss.yaml
@@ -1,9 +1,0 @@
-# GitHub Dependency Review Configuration for Free and Open Source Software
-#
-# Dependency review helps you understand dependency changes and the security impact of these
-# changes.
-#
-# Documentation:
-# - https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review
-
-fail-on-severity: critical


### PR DESCRIPTION
This reverts commit 26ad53417afd9b444988551a6acc86807e196dc8.

The shared configuration file will not be used after all.

Ref: https://cordada.aha.io/features/TECHINFRA-163
Ref: https://github.com/cordada/github-actions-utils/pull/14