### PR TITLE
Update default version of `@commitlint/cli` to 17.4.3

### DIFF
--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -6,7 +6,7 @@ on:
       commitlint_cli_version:
         type: string
         required: false
-        default: "17.0.3"
+        default: "17.4.3"
         description: Commitlint CLI Version
       commitlint_config_cordada_version:
         type: string


### PR DESCRIPTION
[Changelog](https://github.com/conventional-changelog/commitlint/blob/v17.4.3/CHANGELOG.md#1743-2023-02-13)