### PR TITLE
Update default version of `commitlint-config-cordada` to 0.1.1

### DIFF
--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -11,7 +11,7 @@ on:
       commitlint_config_cordada_version:
         type: string
         required: false
-        default: "0.1.0"
+        default: "0.1.1"
         description: Version of Commitlint Configuration for Cordada
       vcs_ref_from:
         type: string


### PR DESCRIPTION
[Changelog](https://github.com/cordada/commitlint-config-cordada/releases/tag/v0.1.1)