### PR TITLE
Release

### DIFF
--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -11,7 +11,7 @@ on:
       commitlint_config_cordada_version:
         type: string
         required: false
-        default: "0.1.0"
+        default: "0.1.1"
         description: Version of Commitlint Configuration for Cordada
       vcs_ref_from:
         type: string

--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -6,7 +6,7 @@ on:
       commitlint_cli_version:
         type: string
         required: false
-        default: "17.0.3"
+        default: "17.4.3"
         description: Commitlint CLI Version
       commitlint_config_cordada_version:
         type: string


### PR DESCRIPTION
## Changes

- (PR #22, 2023-02-16) Update default version of `commitlint-config-cordada` to 0.1.1