### PR TITLE
Update VCS repository of Super-Linter GitHub Action

### DIFF
--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -125,7 +125,7 @@ jobs:
           validate_python_mypy: ${{ inputs.validate_python_mypy }}
 
       - name: Lint
-        uses: github/super-linter/slim@v4.10.1
+        uses: super-linter/super-linter/slim@v4.10.1
         env:
           DEFAULT_BRANCH: ${{ inputs.default_git_branch }}
           LINTER_RULES_PATH: /


### PR DESCRIPTION
The GitHub organization of the Super-Linter VCS repository was changed from `super-linter` to `github`. This commit updates the repository name in the GitHub Action workflow file.

- [Super-Linter ← Actions ← GitHub Marketplace](https://github.com/marketplace/actions/super-linter)
- [Old VCS Repository of Super-Linter](https://github.com/github/super-linter.git)
- [New VCS Repository of Super-Linter](https://github.com/super-linter/super-linter.git)
- [Project name has been changed, breaking the current Action path and a lot of the documentation · Issue #4150 ← super-linter/super-linter](https://github.com/super-linter/super-linter/issues/4150)