### PR TITLE
Release

### DIFF
--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -6,7 +6,7 @@ on:
       commitlint_cli_version:
         type: string
         required: false
-        default: "17.4.3"
+        default: "19.0.3"
         description: Commitlint CLI Version
       commitlint_config_cordada_version:
         type: string
@@ -39,20 +39,21 @@ jobs:
 
     steps:
       - name: Check Out VCS Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.1
         with:
           fetch-depth: 0
 
       - name: Set Up Node.js
-        uses: actions/setup-node@v4
+        id: set_up_nodejs
+        uses: actions/setup-node@v4.0.2
         with:
-          node-version: "16"
+          node-version: "20"
 
       - name: Restoring/Saving Cache
         uses: actions/cache@v4.0.1
         with:
           path: node_modules
-          key: js-v2-deps-${{ runner.os }}-${{ env.COMMITLINT_CLI_VERSION }}-${{ env.COMMITLINT_CONFIG_CORDADA_VERSION }}
+          key: js-v2-deps-${{ runner.os }}-${{ steps.set_up_nodejs.outputs.node-version }}-${{ env.COMMITLINT_CLI_VERSION }}-${{ env.COMMITLINT_CONFIG_CORDADA_VERSION }}
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -49,7 +49,7 @@ jobs:
           node-version: "16"
 
       - name: Restoring/Saving Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4.0.1
         with:
           path: node_modules
           key: js-v2-deps-${{ runner.os }}-${{ env.COMMITLINT_CLI_VERSION }}-${{ env.COMMITLINT_CONFIG_CORDADA_VERSION }}

--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -50,7 +50,7 @@ jobs:
           node-version: "20"
 
       - name: Restoring/Saving Cache
-        uses: actions/cache@v4.0.1
+        uses: actions/cache@v4.0.2
         with:
           path: node_modules
           key: js-v2-deps-${{ runner.os }}-${{ steps.set_up_nodejs.outputs.node-version }}-${{ env.COMMITLINT_CLI_VERSION }}-${{ env.COMMITLINT_CONFIG_CORDADA_VERSION }}

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -125,7 +125,7 @@ jobs:
           validate_python_mypy: ${{ inputs.validate_python_mypy }}
 
       - name: Lint
-        uses: super-linter/super-linter/slim@v5.6.1
+        uses: super-linter/super-linter/slim@v6.3.0
         env:
           DEFAULT_BRANCH: ${{ inputs.default_git_branch }}
           LINTER_RULES_PATH: /

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -125,7 +125,7 @@ jobs:
           validate_python_mypy: ${{ inputs.validate_python_mypy }}
 
       - name: Lint
-        uses: super-linter/super-linter/slim@v6.3.0
+        uses: super-linter/super-linter/slim@v6.4.1
         env:
           DEFAULT_BRANCH: ${{ inputs.default_git_branch }}
           LINTER_RULES_PATH: /


### PR DESCRIPTION
## Changes

- (PR #40, 2024-04-01) chore: Bump the production-dependencies group with 1 update
- (PR #42, 2024-05-10) chore: Bump super-linter/super-linter from 6.3.0 to 6.4.1 in the production-dependencies group