### PR TITLE
Release

### DIFF
--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -6,7 +6,7 @@ on:
       commitlint_cli_version:
         type: string
         required: false
-        default: "19.0.3"
+        default: "19.3.0"
         description: Commitlint CLI Version
       commitlint_config_cordada_version:
         type: string

--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -50,7 +50,7 @@ jobs:
           node-version: "20"
 
       - name: Restoring/Saving Cache
-        uses: actions/cache@v4.0.1
+        uses: actions/cache@v4.0.2
         with:
           path: node_modules
           key: js-v2-deps-${{ runner.os }}-${{ steps.set_up_nodejs.outputs.node-version }}-${{ env.COMMITLINT_CLI_VERSION }}-${{ env.COMMITLINT_CONFIG_CORDADA_VERSION }}

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -125,7 +125,7 @@ jobs:
           validate_python_mypy: ${{ inputs.validate_python_mypy }}
 
       - name: Lint
-        uses: super-linter/super-linter/slim@v6.4.1
+        uses: super-linter/super-linter/slim@v6.6.0
         env:
           DEFAULT_BRANCH: ${{ inputs.default_git_branch }}
           LINTER_RULES_PATH: /

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -125,7 +125,7 @@ jobs:
           validate_python_mypy: ${{ inputs.validate_python_mypy }}
 
       - name: Lint
-        uses: super-linter/super-linter/slim@v6.3.0
+        uses: super-linter/super-linter/slim@v6.4.1
         env:
           DEFAULT_BRANCH: ${{ inputs.default_git_branch }}
           LINTER_RULES_PATH: /


### PR DESCRIPTION
## Changes

- (PR #45, 2024-06-18) chore: Bump super-linter/super-linter from 6.4.1 to 6.6.0 in the production-dependencies group across 1 directory
- (PR #46, 2024-06-18) Update `@commitlint/cli` from 19.0.3 to 19.3.0