### PR TITLE
chore(super-linter): Update default filename for editorconfig-checker

### DIFF
--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -69,7 +69,7 @@ on:
       editorconfig_file_name:
         type: string
         required: false
-        default: .ecrc
+        default: .editorconfig-checker.json
       markdown_config_file:
         type: string
         required: false


### PR DESCRIPTION
The filename `.ecrc` is deprecated and has been replaced by `.editorconfig-checker.json`.

Error message:

```
The default configuration file name `.ecrc` is deprecated. Use `.editorconfig-checker.json` instead. You can simply rename it
```

Ref: https://app.shortcut.com/cordada/story/15640 [sc-15640]