### PR TITLE
Add Super-Linter parameter `filter_regex_exclude`

### DIFF
--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -20,6 +20,10 @@ on:
         required: false
         default: true
         description: When `true`, validate all files; when `false`, only new or edited files.
+      filter_regex_exclude:
+        type: string
+        required: false
+        description: Regular expression defining which files will be excluded from linting.
 
       validate_editorconfig:
         type: boolean
@@ -172,4 +176,5 @@ jobs:
           DEFAULT_BRANCH: ${{ inputs.default_git_branch }}
           LINTER_RULES_PATH: /
           VALIDATE_ALL_CODEBASE: ${{ inputs.validate_all_codebase }}
+          FILTER_REGEX_EXCLUDE: ${{ inputs.filter_regex_exclude }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This parameter can be used to exclude some files from Super-Linter's validations.

CC: @yrios-cdd 