### PR TITLE
fix(super-linter): Change default config file name for `editorconfig`

### DIFF
--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -69,7 +69,7 @@ on:
       editorconfig_file_name:
         type: string
         required: false
-        default: .ecrc
+        default: .editorconfig-checker.json
       markdown_config_file:
         type: string
         required: false


### PR DESCRIPTION
The default name has changed, as this warning explains:

```text
The default configuration file name `.ecrc` is deprecated.
Use `.editorconfig-checker.json` instead. You can simply rename it
```