### PR TITLE
Release

### DIFF
--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -69,7 +69,7 @@ on:
       editorconfig_file_name:
         type: string
         required: false
-        default: .ecrc
+        default: .editorconfig-checker.json
       markdown_config_file:
         type: string
         required: false

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -171,7 +171,7 @@ jobs:
           validate_yaml_prettier: ${{ inputs.validate_yaml_prettier }}
 
       - name: Lint
-        uses: super-linter/super-linter/slim@v7.3.0
+        uses: super-linter/super-linter/slim@v7.4.0
         env:
           DEFAULT_BRANCH: ${{ inputs.default_git_branch }}
           LINTER_RULES_PATH: /


### PR DESCRIPTION
## Changes

- (PR #82, 2025-07-07) chore: Bump super-linter/super-linter from 7.3.0 to 7.4.0 in the github-actions-production group
- (PR #78, 2025-07-07) chore(super-linter): Update default filename for editorconfig-checker