### PR TITLE
Pin GitHub Action `super-linter/super-linter/slim` to commit hash

### DIFF
--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -171,7 +171,7 @@ jobs:
           validate_yaml_prettier: ${{ inputs.validate_yaml_prettier }}
 
       - name: Lint
-        uses: super-linter/super-linter/slim@v7.4.0
+        uses: super-linter/super-linter/slim@12150456a73e248bdc94d0794898f94e23127c88 # v7.4.0
         env:
           DEFAULT_BRANCH: ${{ inputs.default_git_branch }}
           LINTER_RULES_PATH: /


### PR DESCRIPTION
Pin `super-linter/super-linter/slim` to commit hash instead of tag to improve supply chain security.

Resolves: https://github.com/cordada/github-actions-utils/security/code-scanning/9