### PR TITLE
Release

### DIFF
--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -50,7 +50,7 @@ jobs:
           node-version: "lts/*"
 
       - name: Restoring/Saving Cache
-        uses: actions/cache@v5.0.3
+        uses: actions/cache@v5.0.5
         with:
           path: node_modules
           key: js-v2-deps-${{ runner.os }}-${{ steps.set_up_nodejs.outputs.node-version }}-${{ env.COMMITLINT_CLI_VERSION }}-${{ env.COMMITLINT_CONFIG_CORDADA_VERSION }}

--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Set Up Node.js
         id: set_up_nodejs
-        uses: actions/setup-node@v6.2.0
+        uses: actions/setup-node@v6.4.0
         with:
           node-version: "lts/*"
 

--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Check Out VCS Repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -178,7 +178,7 @@ jobs:
           validate_yaml_prettier: ${{ inputs.validate_yaml_prettier }}
 
       - name: Lint
-        uses: super-linter/super-linter/slim@61abc07d755095a68f4987d1c2c3d1d64408f1f9 # v8.5.0
+        uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
         env:
           DEFAULT_BRANCH: ${{ inputs.default_git_branch }}
           LINTER_RULES_PATH: /

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -107,7 +107,7 @@ jobs:
 
     steps:
       - name: Check Out VCS Repository
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v6.0.3
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`.
           fetch-depth: 0


### PR DESCRIPTION
## Changes

- (PR #103, 2026-06-02) chore(deps): Bump actions/checkout from 6.0.2 to 6.0.3
- (PR #98, 2026-06-02) chore(deps): Bump super-linter/super-linter from 8.5.0 to 8.6.0
- (PR #102, 2026-06-02) chore(deps): Bump actions/cache from 5.0.3 to 5.0.5
- (PR #101, 2026-06-03) chore(deps): Bump actions/setup-node from 6.2.0 to 6.4.0
