### PR TITLE
Release

### DIFF
--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -69,7 +69,8 @@ jobs:
 
       - name: Lint Git Commit Messages
         run: |
-          npm exec -- commitlint --from "$VCS_REF_FROM" --to "$VCS_REF_TO"
+          npm exec -- commitlint --from "$VCS_REF_FROM" --to "$VCS_REF_TO" \
+            --git-log-args '--no-merges'
         env:
           VCS_REF_FROM: ${{ inputs.vcs_ref_from }}
           VCS_REF_TO: ${{ inputs.vcs_ref_to }}

--- a/.github/workflows/git-commit-lint.yaml
+++ b/.github/workflows/git-commit-lint.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Lint Git Commit Messages
         run: |
           npm exec -- commitlint --from "$VCS_REF_FROM" --to "$VCS_REF_TO" \
-            --git-log-args '--no-merges'
+            --git-log-args='--no-merges'
         env:
           VCS_REF_FROM: ${{ inputs.vcs_ref_from }}
           VCS_REF_TO: ${{ inputs.vcs_ref_to }}

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -178,7 +178,7 @@ jobs:
           validate_yaml_prettier: ${{ inputs.validate_yaml_prettier }}
 
       - name: Lint
-        uses: super-linter/super-linter/slim@9e863354e3ff62e0727d37183162c4a88873df41 # v8.6.0
+        uses: super-linter/super-linter/slim@4ce20838b8ab83717e78138c5b3a1407148e0918 # v8.7.0
         env:
           DEFAULT_BRANCH: ${{ inputs.default_git_branch }}
           LINTER_RULES_PATH: /


### PR DESCRIPTION
## Changes

- (PR #105, 2026-06-23) Exclude merge commits when linting Git commit messages
- (PR #106, 2026-06-23) Fix incorrect command line argument parsing in Git commit linter
- (PR #107, 2026-06-23) chore(deps): Bump super-linter/super-linter from 8.6.0 to 8.7.0
